### PR TITLE
Remove gathering from title

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
   <!-- Press Coverage -->
   <div class="section community">
     <div class="container">
-      <h2>The developers community<br>gathering in Crete</h2>
+      <h2>The developers community<br>in Crete</h2>
     </div>
     <div id="about" class="highlight">
       <div class="container">


### PR DESCRIPTION
DevStaff is a community by now. Not just a meetup.
And this site is about the community, not the meetup (any more) ;)